### PR TITLE
Fix: Update open ssl security level

### DIFF
--- a/lib/grocer/ssl_connection.rb
+++ b/lib/grocer/ssl_connection.rb
@@ -22,6 +22,7 @@ module Grocer
 
     def connect
       context = OpenSSL::SSL::SSLContext.new
+      context.security_level = 1
 
       if certificate
 


### PR DESCRIPTION
Fixes: https://github.com/Shopify/shopify/issues/274595

Apple pass certificates are generated with SHA1 which are now incompatible with the default security level 2 in OpenSSL. 
In gift cards, we depend on grocer gem to send passbook notification. 
After discussions with @clayton-shopify, we went ahead with the approach to fork the grocer gem and patch it, instead of directly monkey-patching the context to update the security level in core. 

This PR Update the security level of ssl to 1 to handle weak certificate error for apple certificates for Passbook notification

Open SSL [documentation](https://ruby-doc.org/stdlib-2.7.0/libdoc/openssl/rdoc/OpenSSL/SSL/SSLContext.html#method-i-security_level-3D)

The reason we are seeing this errors now is because of the Ubuntu update to 20.04 from 16.04. Ubuntu 20.04 sets the openssl security level to 2 by default as compared to 1 in Ubuntu 16.04. The security implications of this would be are reverting to SHA1 level of security. More about that [here](https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_get_security_level.html) 

This solution is a quick fix. In the long term, we would either want to handle the notification with something in house at shopify or use a more actively maintainable gem like [Aptonic](https://rubygems.org/gems/apnotic/versions/1.3.0) which is already working on the fix for this issue. 